### PR TITLE
Add math.h to be able to use the error without include errors

### DIFF
--- a/Library/libs.h
+++ b/Library/libs.h
@@ -13,6 +13,7 @@
 #include <stdint.h>  ///< Std types
 #include <stdbool.h> ///< _Bool to bool
 #include <string.h>	 ///< Lib for sprintf, strlen, etc
+#include <math.h>    ///< Lib for the float_t type
 
 typedef uint8_t u8_t; 	///< 8-bit unsigned
 typedef int8_t i8_t;	///< 8-bit signed


### PR DESCRIPTION
I have been using the library for a personal project for a while now, and the float_t type needs me to import the math.h library to my codebase. If this is needed for the library to work, i think adding it to the libs.h file is a good proposal. I have also run the code fine without the fl_t typedef for a while now, and not encountered any issues, so an alternative approach might be to just remove the fl_t ypedef alltogether.